### PR TITLE
Upgrading Monolog's require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "Monolog"
     ],
     "require": {
-        "monolog/monolog":                      "~1.6.0",
+        "monolog/monolog":                      "~1.6",
         "zendframework/zendframework":          "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Monolog is already at version 1.7, so this enable ">=1.6,<2.0 "
