### PR TITLE
add code coverage summary to travis output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - composer --dev install
 
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --coverage-text
 
 notifications:
   email: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,4 +4,9 @@
             <directory>./test/EnliteMonologTest</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
add-coverage-to-build - add phpunit code coverage whitelist, and add coverage-text attribute to test runner so that a line coverage report is displayed in the build output.