### PR TITLE
replaced ZFramework dependency with specific components.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,22 @@
         "Monolog"
     ],
     "require": {
-        "monolog/monolog":                      "~1.6",
-        "zendframework/zendframework":          "~2.2"
+        "monolog/monolog": "^1.1",
+        "zendframework/zend-modulemanager": "^2",
+        "zendframework/zend-stdlib": "^2",
+        "zendframework/zend-servicemanager": "^2"
     },
     "require-dev": {
-        "phpunit/phpunit":                      "~3.7"
+        "phpunit/phpunit": "^5|^4|^3"
     },
     "autoload": {
-        "psr-0": {
-            "EnliteMonolog": "src"
+        "psr-4": {
+            "EnliteMonolog\\": "src/EnliteMonolog"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "EnliteMonologTest\\": "test/EnliteMonologTest"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./test/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>./test/EnliteMonologTest</directory>

--- a/src/EnliteMonolog/Service/MonologServiceFactory.php
+++ b/src/EnliteMonolog/Service/MonologServiceFactory.php
@@ -8,11 +8,10 @@ namespace EnliteMonolog\Service;
 
 use Closure;
 use Exception;
+use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Formatter\FormatterInterface;
 use RuntimeException;
-use Zend\Code\Reflection\ClassReflection;
-use Zend\Log\LoggerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -54,7 +53,7 @@ class MonologServiceFactory implements FactoryInterface
      * @param MonologOptions $options
      * @param string|array $handler
      * @throws \RuntimeException
-     * @return LoggerInterface
+     * @return HandlerInterface
      *
      */
     public function createHandler(ServiceLocatorInterface $serviceLocator, MonologOptions $options, $handler)
@@ -75,7 +74,7 @@ class MonologServiceFactory implements FactoryInterface
                     throw new RuntimeException('Arguments of handler(' . $handler['name'] . ') must be array');
                 }
 
-                $reflection = new ClassReflection($handler['name']);
+                $reflection = new \ReflectionClass($handler['name']);
 
                 if (isset($handler['args']['handler'])) {
                     foreach ($options->getHandlers() as $key => $option) {
@@ -127,7 +126,7 @@ class MonologServiceFactory implements FactoryInterface
 					throw new RuntimeException('Arguments of formatter(' . $formatter['name'] . ') must be array');
 				}
 
-				$reflection = new ClassReflection($formatter['name']);
+				$reflection = new \ReflectionClass($formatter['name']);
 
 				return call_user_func_array(array($reflection, 'newInstance'), $formatter['args']);
 			}


### PR DESCRIPTION
* replace Zend Framework dependency with more targeted list of components (only the ones used by src and test).
* loosen dependency versions (this package works with even the oldest versions of Service Manager).
* replace test bootstrap with vendor autoload script.
* add php56 and php70 to travis build. woohoo! it passes.
* replaced zend-code ClassReflection dependency with \ReflectionClass. same effect, less dependency.

i submitted a previous merge request with additional coverage. i cross-checked that request with this one and it appears to be compatible.