### PR TITLE
Changed logic of parsing Handler args from config.

### DIFF
--- a/config/monolog.global.php.dist
+++ b/config/monolog.global.php.dist
@@ -11,7 +11,7 @@ return array(
                 'default' => array(
                     'name' => 'Monolog\Handler\StreamHandler',
                     'args' => array(
-                        'path' => 'data/log/application.log',
+                        'stream' => 'data/log/application.log',
                         'level' => \Monolog\Logger::DEBUG,
                         'bubble' => true
                     )

--- a/src/EnliteMonolog/Service/MonologServiceFactory.php
+++ b/src/EnliteMonolog/Service/MonologServiceFactory.php
@@ -90,7 +90,7 @@ class MonologServiceFactory implements FactoryInterface
 
                 $requiredArgsCount = $reflection->getConstructor()->getNumberOfRequiredParameters();
 
-                if ($requiredArgsCount < sizeof($handlerOptions)) {
+                if ($requiredArgsCount > sizeof($handlerOptions)) {
                     throw new RuntimeException(sprintf('Handler(%s) requires at least %d params. Only %d passed.', $handler['name'], $requiredArgsCount, sizeof($handlerOptions)));
                 }
 

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -159,7 +159,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateFormatterFromServiceName()
     {
         $serviceManager = new ServiceManager();
-        $serviceManager->setService('MyFormatter', $expected = self::createMock('\Monolog\Formatter\FormatterInterface'));
+        $serviceManager->setService('MyFormatter', $expected = $this->getMock('\Monolog\Formatter\FormatterInterface'));
 
         $factory = new MonologServiceFactory();
 

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -115,9 +115,9 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new MonologServiceFactory();
 
         $actual = $factory->createProcessor($serviceManager, $expected = function () {
-            
+
         });
-        
+
         self::assertSame($expected, $actual);
     }
 
@@ -127,7 +127,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager->setService('MyProcessor', $expected = function () {
 
         });
-        
+
         $factory = new MonologServiceFactory();
 
         $actual = $factory->createProcessor($serviceManager, 'MyProcessor');
@@ -155,16 +155,16 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->createProcessor($serviceManager, '\stdClass');
     }
-    
+
     public function testCreateFormatterFromServiceName()
     {
         $serviceManager = new ServiceManager();
-        $serviceManager->setService('MyFormatter', $expected = $this->getMock('\Monolog\Formatter\FormatterInterface'));
-        
+        $serviceManager->setService('MyFormatter', $expected = self::createMock('\Monolog\Formatter\FormatterInterface'));
+
         $factory = new MonologServiceFactory();
 
         $actual = $factory->createFormatter($serviceManager, 'MyFormatter');
-        
+
         self::assertSame($expected, $actual);
     }
 
@@ -177,7 +177,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new MonologServiceFactory();
 
         $factory->createFormatter($serviceManager, array(
-            
+
         ));
     }
 
@@ -207,7 +207,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
             'args' => 'MyArgs',
         ));
     }
-    
+
     public function testCreateFormatterWithArguments()
     {
         $serviceManager = new ServiceManager();
@@ -220,10 +220,10 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
                 'dateFormat' => 'Y-m-d H:i:s',
             ),
         ));
-        
+
         self::assertInstanceOf('\Monolog\Formatter\LineFormatter', $actual);
     }
-    
+
     public function testCreateFormatterWithoutArguments()
     {
         $serviceManager = new ServiceManager();
@@ -235,36 +235,54 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
         self::assertInstanceOf('\Monolog\Formatter\LineFormatter', $actual);
     }
-    
+
     public function testCreateLoggerWithProcessor()
     {
         $options = new MonologOptions();
         $options->setProcessors(array(
             '\Monolog\Processor\MemoryUsageProcessor',
         ));
-        
+
         $serviceManager = new ServiceManager();
         $factory = new MonologServiceFactory();
-        
+
         $actual = $factory->createLogger($serviceManager, $options);
-        
+
         self::assertInstanceOf('\Monolog\Logger', $actual);
         self::assertInstanceOf('\Monolog\Processor\MemoryUsageProcessor', $actual->popProcessor());
     }
-    
+
     public function testCreateHandlerWithFormatter()
     {
         $serviceManager = new ServiceManager();
         $factory = new MonologServiceFactory();
-        
+
         $actual = $factory->createHandler($serviceManager, new MonologOptions(), array(
             'name' => '\Monolog\Handler\NullHandler',
             'formatter' => array(
                 'name' => '\Monolog\Formatter\LineFormatter',
             ),
         ));
-        
+
         self::assertInstanceOf('\Monolog\Handler\NullHandler', $actual);
         self::assertInstanceOf('\Monolog\Formatter\LineFormatter', $actual->getFormatter());
+    }
+
+    public function testCreateHandlerWithRandomOrderArgs()
+    {
+        $config = array('name' => 'test', 'handlers' => array(array('name' => 'Monolog\Handler\TestHandler')));
+
+        $serviceManager = new ServiceManager();
+        $factory = new MonologServiceFactory();
+
+        /** @var \Monolog\Handler\TestHandler $handler */
+        $handler = $factory->createHandler($serviceManager, new MonologOptions($config), array(
+            'name' => 'Monolog\Handler\TestHandler',
+            'args' => array(
+                'bubble' => false
+            )
+        ));
+
+        self::assertFalse($handler->getBubble());
     }
 }


### PR DESCRIPTION
#12 
args from Handler config are passed to constructor by matching name, but with priority to required arguments.

For example
```php
'name' => 'Monolog\Handler\RotatingFileHandler',
'args' => array(
    'level' => \Monolog\Logger::DEBUG,
    'useLocking' => true,
    'filename' => 'data/log/debug.log',
),
```
will create `RotatingFileHandler` with passed params using default values for other args.

```php
'name' => 'Monolog\Handler\RotatingFileHandler',
'args' => array(
    \Monolog\Logger::DEBUG,
     true,
    'data/log/debug.log',
),
```
Will fail because of trying pass `\Monolog\Logger::DEBUG` as `fileName`.

```php
'name' => 'Monolog\Handler\RotatingFileHandler',
'args' => array(
    'data/log/debug.log',
    100,
    \Monolog\Logger::DEBUG,
    true,
    null,
    true
),
```
will pass to constructor only `fileName` ignoring other params, because they are optional and don't have identifier in config.

Basic test included.