### PR TITLE
FIX: support for monolog/monolog v ^1.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "zendframework/zend-servicemanager": "^2 || ^3"
     },
     "require-dev": {
-        "monolog/monolog": "^1.16.0",
         "phpunit/phpunit": "^5|^4|^3"
     },
     "autoload": {

--- a/src/EnliteMonolog/Service/MonologServiceFactory.php
+++ b/src/EnliteMonolog/Service/MonologServiceFactory.php
@@ -48,11 +48,10 @@ class MonologServiceFactory implements FactoryInterface
     {
         $logger = new Logger($options->getName());
 
-        $handlers = array();
-        foreach ($options->getHandlers() as $handler) {
-            $handlers[] = $this->createHandler($container, $options, $handler);
+        $handlers = array_reverse($options->getHandlers());
+        foreach ($handlers as $handler) {
+            $logger->pushHandler($this->createHandler($container, $options, $handler));
         }
-        $logger->setHandlers($handlers);
 
         foreach ($options->getProcessors() as $processor) {
             $logger->pushProcessor($this->createProcessor($container, $processor));

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -313,8 +313,13 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $service = $factory->createService($serviceManager);
 
         $service->addError('HandleThis!');
-        $handlers = $service->getHandlers();
-        self::assertCount(2, $handlers);
+
+        $handler1 = $service->popHandler();
+        $this->assertInstanceOf('Monolog\Handler\TestHandler', $handler1);
+
+        $handler2 = $service->popHandler();
+        $this->assertInstanceOf('Monolog\Handler\NullHandler', $handler2);
+
         self::assertTrue($handler->hasErrorRecords());
     }
 }


### PR DESCRIPTION
previously enlitepro/enlite-monolog was supporting ^1.16.0 of monolog/monolog