### PR TITLE
add configuration to register logger as an error-handler.

### DIFF
--- a/src/EnliteMonolog/Service/MonologOptions.php
+++ b/src/EnliteMonolog/Service/MonologOptions.php
@@ -31,6 +31,13 @@ class MonologOptions extends AbstractOptions
     protected $processors = array();
 
     /**
+     * Register logger as error, exception, and fatal handler.
+     *
+     * @var bool
+     */
+    protected $isErrorHandler = false;
+
+    /**
      * @param string $name
      */
     public function setName($name)
@@ -78,4 +85,20 @@ class MonologOptions extends AbstractOptions
         return $this->processors;
     }
 
+    /**
+     * @return boolean
+     */
+    public function isErrorHandler()
+    {
+        return $this->isErrorHandler;
+    }
+
+    /**
+     * @param boolean $isErrorHandler
+     * @return void
+     */
+    public function setIsErrorHandler($isErrorHandler)
+    {
+        $this->isErrorHandler = (bool) $isErrorHandler;
+    }
 }

--- a/src/EnliteMonolog/Service/MonologServiceFactory.php
+++ b/src/EnliteMonolog/Service/MonologServiceFactory.php
@@ -9,6 +9,7 @@ namespace EnliteMonolog\Service;
 use Closure;
 use Exception;
 use Interop\Container\ContainerInterface;
+use Monolog\ErrorHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Formatter\FormatterInterface;
@@ -55,6 +56,10 @@ class MonologServiceFactory implements FactoryInterface
 
         foreach ($options->getProcessors() as $processor) {
             $logger->pushProcessor($this->createProcessor($container, $processor));
+        }
+
+        if (class_exists('\Monolog\ErrorHandler') && $options->isErrorHandler()) {
+            ErrorHandler::register($logger);
         }
 
         return $logger;

--- a/test/EnliteMonologTest/Service/MonologOptionsTest.php
+++ b/test/EnliteMonologTest/Service/MonologOptionsTest.php
@@ -4,6 +4,9 @@ namespace EnliteMonologTest\Service;
 
 use EnliteMonolog\Service\MonologOptions;
 
+/**
+ * @covers \EnliteMonolog\Service\MonologOptions
+ */
 class MonologOptionsTest extends \PHPUnit_Framework_TestCase
 {
     /** @var MonologOptions */
@@ -62,5 +65,19 @@ class MonologOptionsTest extends \PHPUnit_Framework_TestCase
 
         self::assertInternalType('array', $this->sut->getProcessors());
         self::assertContains($expected, $this->sut->getProcessors());
+    }
+
+    public function testDefaultIsErrorHandler()
+    {
+        $actual = $this->sut->isErrorHandler();
+
+        self::assertFalse($actual);
+    }
+
+    public function testSetIsErrorHandler()
+    {
+        $this->sut->setIsErrorHandler(true);
+
+        self::assertTrue($this->sut->isErrorHandler());
     }
 }

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -159,7 +159,10 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreateFormatterFromServiceName()
     {
         $serviceManager = new ServiceManager();
-        $serviceManager->setService('MyFormatter', $expected = $this->getMock('\Monolog\Formatter\FormatterInterface'));
+        $serviceManager->setService(
+            'MyFormatter',
+            $expected = $this->getMockBuilder('\Monolog\Formatter\FormatterInterface')->getMock()
+        );
 
         $factory = new MonologServiceFactory();
 
@@ -321,5 +324,18 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Monolog\Handler\NullHandler', $handler2);
 
         self::assertTrue($handler->hasErrorRecords());
+    }
+
+    public function testCreateLoggerIsErrorHandler()
+    {
+        $options = new MonologOptions();
+        $options->setIsErrorHandler(true);
+
+        $serviceManager = new ServiceManager();
+        $factory = new MonologServiceFactory();
+
+        $actual = $factory->createLogger($serviceManager, $options);
+
+        self::assertInstanceOf('\Monolog\Logger', $actual);
     }
 }


### PR DESCRIPTION
`\Monolog\ErrorHandler` (and its `register` method) have been available in monolog since 1.6.0. i thought it would be neat to offer the configurability to register a logger as an error handler. it's off by default, and multiple loggers can be registered as error handlers. this is something i'd be able to use in my application immediately.

the register method accepts additional params that have default values. we could extend the options object to allow additional configuration, but i didn't see the need at this time.

what do you think?

note: i changed the way an existing class was mocked to avoid deprecation warnings in the newest versions of phpunit.