### PR TITLE
add tests to improve coverage

### DIFF
--- a/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
@@ -6,6 +6,8 @@
 namespace EnliteMonologTest\Service;
 
 use EnliteMonolog\Service\MonologServiceAbstractFactory;
+use Interop\Container\ContainerInterface;
+use Monolog\Logger;
 use Zend\ServiceManager\ServiceManager;
 
 class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
@@ -77,6 +79,52 @@ class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
 
         $logger = $factory->createServiceWithName($serviceLocator, 'default', 'default');
         
+        self::assertInstanceOf('\Monolog\Logger', $logger);
+    }
+
+    public function testCanCreate()
+    {
+        $services = new ServiceManager();
+
+        if (!$services instanceof ContainerInterface) {
+            self::markTestSkipped('container-interop/container-interop is required.');
+        }
+
+        $sut = new MonologServiceAbstractFactory();
+
+        $services->setService(
+            'config',
+            array(
+                'EnliteMonolog' => array(
+                    'default' => array()
+                )
+            )
+        );
+
+        self::assertTrue($sut->canCreate($services, 'default'));
+    }
+
+    public function testInvoke()
+    {
+        $services = new ServiceManager();
+
+        if (!$services instanceof ContainerInterface) {
+            self::markTestSkipped('container-interop/container-interop is required.');
+        }
+
+        $sut = new MonologServiceAbstractFactory();
+
+        $services->setService(
+            'config',
+            array(
+                'EnliteMonolog' => array(
+                    'default' => array()
+                )
+            )
+        );
+
+        $logger = $sut($services, 'default');
+
         self::assertInstanceOf('\Monolog\Logger', $logger);
     }
 }

--- a/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Monolog\Logger;
+
+/**
+ * @requires PHP 5.4
+ */
+class MonologServiceAwareTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetMonologService()
+    {
+        /** @var MonologServiceAwareTrait $trait */
+        $trait = $this->getMockForTrait('\EnliteMonolog\Service\MonologServiceAwareTrait');
+
+        $logger = new Logger(__METHOD__);
+
+        $trait->setMonologService($logger);
+
+        self::assertSame($logger, $trait->getMonologService());
+    }
+}

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -7,6 +7,7 @@ namespace EnliteMonologTest\Service;
 
 use EnliteMonolog\Service\MonologOptions;
 use EnliteMonolog\Service\MonologServiceFactory;
+use Interop\Container\ContainerInterface;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
 use Zend\ServiceManager\ServiceManager;
@@ -384,5 +385,26 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         ));
 
         self::assertContains('[2016-01-01 00:00:00]', $line);
+    }
+
+    public function testInvoke()
+    {
+        $services = new ServiceManager();
+
+        if (!$services instanceof ContainerInterface) {
+            self::markTestSkipped('container-interop/container-interop is required.');
+        }
+
+        $config = array('name' => 'test', 'handlers' => array(array('name' => 'Monolog\Handler\TestHandler')));
+
+        $services->setService('EnliteMonologOptions', new MonologOptions($config));
+
+        $sut = new MonologServiceFactory();
+
+        $service = $sut($services, 'EnliteMonolog');
+        $this->assertInstanceOf('Monolog\Logger', $service);
+        $this->assertEquals('test', $service->getName());
+
+        $this->assertInstanceOf('Monolog\Handler\TestHandler', $service->popHandler());
     }
 }


### PR DESCRIPTION
add tests to improve coverage. trait test will only run on >=php54, and the container-interop tests check service manager interfaces before execution.