### PR TITLE
demonstrate trait bug

### DIFF
--- a/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
@@ -4,6 +4,7 @@ namespace EnliteMonologTest\Service;
 
 use EnliteMonolog\Service\MonologServiceAwareTrait;
 use Monolog\Logger;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * @requires PHP 5.4
@@ -20,5 +21,86 @@ class MonologServiceAwareTraitTest extends \PHPUnit_Framework_TestCase
         $trait->setMonologService($logger);
 
         self::assertSame($logger, $trait->getMonologService());
+    }
+
+    public function testGetMonologServiceViaServiceLocatorAwareInterface()
+    {
+        if (!\interface_exists('\Zend\ServiceManager\ServiceLocatorAwareInterface')) {
+            self::markTestSkipped('\Zend\ServiceManager\ServiceLocatorAwareInterface is required.');
+        }
+
+        $sut = new TraitMock();
+
+        $logger = new Logger(__METHOD__);
+
+        $services = new ServiceManager();
+        $services->setService('EnliteMonologService', $logger);
+
+        $sut->setServiceLocator($services);
+
+        self::assertSame($logger, $sut->getMonologService());
+    }
+
+    public function testGetMonologServiceViaServiceLocatorAwareTrait()
+    {
+        if (!\trait_exists('\Zend\ServiceManager\ServiceLocatorAwareTrait')) {
+            self::markTestSkipped('\Zend\ServiceManager\ServiceLocatorAwareTrait is required.');
+        }
+
+        $sut = new TraitMock2();
+
+        $logger = new Logger(__METHOD__);
+
+        $services = new ServiceManager();
+        $services->setService('EnliteMonologService', $logger);
+
+        $sut->setServiceLocator($services);
+
+        self::assertSame($logger, $sut->getMonologService());
+    }
+
+    public function testGetMonologServiceViaServiceLocatorMethod()
+    {
+        $sut = new TraitMock3();
+
+        $logger = new Logger(__METHOD__);
+
+        $services = new ServiceManager();
+        $services->setService('EnliteMonologService', $logger);
+
+        $sut->setServiceLocator($services);
+
+        self::assertSame($logger, $sut->getMonologService());
+    }
+
+    public function testGetMonologServiceViaServiceLocatorProperty()
+    {
+        $sut = new TraitMock4();
+
+        $logger = new Logger(__METHOD__);
+
+        $services = new ServiceManager();
+        $services->setService('EnliteMonologService', $logger);
+
+        $sut->setServiceLocator($services);
+
+        self::assertSame($logger, $sut->getMonologService());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testNotGetMonologService()
+    {
+        $sut = new TraitMock5();
+
+        $logger = new Logger(__METHOD__);
+
+        $services = new ServiceManager();
+        $services->setService('EnliteMonologService', $logger);
+
+        $sut->setServiceLocator($services);
+
+        $sut->getMonologService();
     }
 }

--- a/test/EnliteMonologTest/Service/TraitMock.php
+++ b/test/EnliteMonologTest/Service/TraitMock.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class TraitMock implements ServiceLocatorAwareInterface
+{
+    use MonologServiceAwareTrait;
+
+    /** @var ServiceLocatorInterface */
+    private $services;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->services = $serviceLocator;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->services;
+    }
+}

--- a/test/EnliteMonologTest/Service/TraitMock2.php
+++ b/test/EnliteMonologTest/Service/TraitMock2.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class TraitMock2
+{
+    use MonologServiceAwareTrait;
+    use ServiceLocatorAwareTrait;
+}

--- a/test/EnliteMonologTest/Service/TraitMock3.php
+++ b/test/EnliteMonologTest/Service/TraitMock3.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class TraitMock3
+{
+    use MonologServiceAwareTrait;
+
+    /** @var ServiceLocatorInterface */
+    private $services;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->services = $serviceLocator;
+    }
+
+    /**
+     * Get service locator
+     *
+     * @return ServiceLocatorInterface
+     */
+    public function getServiceLocator()
+    {
+        return $this->services;
+    }
+}

--- a/test/EnliteMonologTest/Service/TraitMock4.php
+++ b/test/EnliteMonologTest/Service/TraitMock4.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class TraitMock4
+{
+    use MonologServiceAwareTrait;
+
+    /** @var ServiceLocatorInterface */
+    private $serviceLocator;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+}

--- a/test/EnliteMonologTest/Service/TraitMock5.php
+++ b/test/EnliteMonologTest/Service/TraitMock5.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\MonologServiceAwareTrait;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class TraitMock5
+{
+    use MonologServiceAwareTrait;
+
+    /** @var ServiceLocatorInterface */
+    private $services;
+
+    /**
+     * Set service locator
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     */
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->services = $serviceLocator;
+    }
+}


### PR DESCRIPTION
add some more trait tests, covering ServiceLocatorAwareInterface, ServiceLocatorAwareTrait, getServiceLocator method, and the serviceLocator property. serviceLocator property fails because of a bug that @gander will fix in #30 