### PR TITLE
100% line coverage

### DIFF
--- a/test/EnliteMonologTest/Service/FormatterMock.php
+++ b/test/EnliteMonologTest/Service/FormatterMock.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use Monolog\Formatter\FormatterInterface;
+
+class FormatterMock implements FormatterInterface
+{
+    /** @var callable */
+    private $encoder;
+
+    /**
+     * FormatterMock constructor.
+     * @param callable $encoder
+     */
+    public function __construct($encoder)
+    {
+        if (!is_callable($encoder)) {
+            throw new \RuntimeException('Encoder must be callable.');
+        }
+
+        $this->encoder = $encoder;
+    }
+
+    /**
+     * Formats a log record.
+     *
+     * @param  array $record A record to format
+     * @return mixed The formatted record
+     */
+    public function format(array $record)
+    {
+        return call_user_func($this->encoder, $record);
+    }
+
+    /**
+     * Formats a set of log records.
+     *
+     * @param  array $records A set of records to format
+     * @return mixed The formatted set of records
+     */
+    public function formatBatch(array $records)
+    {
+        return array_map(array($this, 'format'), $records);
+    }
+}

--- a/test/EnliteMonologTest/Service/FormatterPrivateConstructorMock.php
+++ b/test/EnliteMonologTest/Service/FormatterPrivateConstructorMock.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use Monolog\Formatter\FormatterInterface;
+
+final class FormatterPrivateConstructorMock implements FormatterInterface
+{
+    /**
+     * FormatterNamedFactoryMock constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    public static function create()
+    {
+        return new self;
+    }
+
+
+    /**
+     * Formats a log record.
+     *
+     * @param  array $record A record to format
+     * @return mixed The formatted record
+     */
+    public function format(array $record)
+    {
+        return json_encode($record);
+    }
+
+    /**
+     * Formats a set of log records.
+     *
+     * @param  array $records A set of records to format
+     * @return mixed The formatted set of records
+     */
+    public function formatBatch(array $records)
+    {
+        return array_map(array($this, 'format'), $records);
+    }
+}

--- a/test/EnliteMonologTest/Service/MonologOptionsTest.php
+++ b/test/EnliteMonologTest/Service/MonologOptionsTest.php
@@ -4,6 +4,9 @@ namespace EnliteMonologTest\Service;
 
 use EnliteMonolog\Service\MonologOptions;
 
+/**
+ * @covers \EnliteMonolog\Service\MonologOptions
+ */
 class MonologOptionsTest extends \PHPUnit_Framework_TestCase
 {
     /** @var MonologOptions */

--- a/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
@@ -10,6 +10,9 @@ use Interop\Container\ContainerInterface;
 use Monolog\Logger;
 use Zend\ServiceManager\ServiceManager;
 
+/**
+ * @covers \EnliteMonolog\Service\MonologServiceAbstractFactory
+ */
 class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAwareTraitTest.php
@@ -8,6 +8,7 @@ use Zend\ServiceManager\ServiceManager;
 
 /**
  * @requires PHP 5.4
+ * @covers \EnliteMonolog\Service\MonologServiceAwareTrait
  */
 class MonologServiceAwareTraitTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
add a few more tests to cover factory and initializer. use `@covers` annotation for more accurate line coverage.

testCreateHandlerFromOptions is a little wacky. i'm not sure what the real use-case is here. if anyone could fill me in that would be great. i'd be happy to create a new test which more accurately reflects the real-world configuration that caused this code to be written. for now, this gives us the missing coverage.