### PR TITLE
WIP test logger alias

### DIFF
--- a/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
@@ -8,6 +8,7 @@ namespace EnliteMonologTest\Service;
 use EnliteMonolog\Service\MonologServiceAbstractFactory;
 use Interop\Container\ContainerInterface;
 use Monolog\Logger;
+use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 
 /**
@@ -127,6 +128,41 @@ class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         $logger = $sut($services, 'default');
+
+        self::assertInstanceOf('\Monolog\Logger', $logger);
+    }
+
+    public function testCreateServiceFromServiceManager()
+    {
+        $services = new ServiceManager();
+        $services->addAbstractFactory(new MonologServiceAbstractFactory());
+        $services->setService('config', array(
+            'EnliteMonolog' => array(
+                'FooBar' => array(
+                    'name' => 'FooBar',
+                ),
+            ),
+        ));
+
+        $logger = $services->get('FooBar');
+
+        self::assertInstanceOf('\Monolog\Logger', $logger);
+    }
+
+    public function testCreateAliasedServiceFromServiceManager()
+    {
+        $services = new ServiceManager();
+        $services->addAbstractFactory(new MonologServiceAbstractFactory());
+        $services->setAlias('FizBuz', 'FooBar');
+        $services->setService('config', array(
+            'EnliteMonolog' => array(
+                'FooBar' => array(
+                    'name' => 'FooBar',
+                ),
+            ),
+        ));
+
+        $logger = $services->get('FizBuz');
 
         self::assertInstanceOf('\Monolog\Logger', $logger);
     }


### PR DESCRIPTION
fixes #25 

add integration tests covering service-manager configuration and ability to alias enlite loggers.

this appears to be a problem in zend-servicemanager:^2, as it looks like all zend-servicemanager:^3 builds are successful.