### PR TITLE
catch a couple of mutants by strictly asserting exception codes.

### DIFF
--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -77,6 +77,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateHandlerByEmptyClassname()
     {
@@ -90,6 +91,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateHandlerNotExistsClassname()
     {
@@ -103,6 +105,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateHandlerWithBadArgs()
     {
@@ -153,6 +156,8 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
+     * @expectedExceptionMessage Unknown processor type, must be a Closure or the FQCN of an invokable class
      */
     public function testCreateProcessorNotExistsClassName()
     {
@@ -160,6 +165,21 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new MonologServiceFactory();
 
         $factory->createProcessor($serviceManager, '\stdClass');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
+     * @expectedExceptionMessage Unknown processor type, must be a Closure or the FQCN of an invokable class
+     */
+    public function testCreateNonCallableProcessorFromServiceName()
+    {
+        $services = new ServiceManager();
+        $services->setService('\stdClass', new \stdClass());
+
+        $sut = new MonologServiceFactory();
+
+        $sut->createProcessor($services, '\stdClass');
     }
 
     public function testCreateFormatterFromServiceName()
@@ -179,6 +199,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateFormatterWithMissingFormatterNameConfig()
     {
@@ -192,6 +213,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateFormatterNotExistsClassName()
     {
@@ -205,6 +227,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      */
     public function testCreateFormatterWithInvalidFormatterArgumentConfig()
     {
@@ -440,6 +463,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      * @expectedExceptionMessage Handler(\EnliteMonologTest\Service\HandlerMock) has an invalid argument configuration
      */
     public function testCreateHandlerWithInvalidArguments()
@@ -458,6 +482,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      * @expectedExceptionMessage Formatter(\EnliteMonologTest\Service\FormatterMock) has an invalid argument config
      */
     public function testCreateFormatterWithMissingArguments()
@@ -474,6 +499,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      * @expectedExceptionMessage Formatter(\EnliteMonologTest\Service\FormatterMock) has an invalid argument config
      */
     public function testCreateFormatterWithInvalidArguments()
@@ -492,6 +518,7 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \RuntimeException
+     * @expectedExceptionCode 0
      * @expectedExceptionMessage Formatter(\EnliteMonologTest\Service\FormatterPrivateConstructorMock) has an invalid
      */
     public function testCreateFormatterWithPrivateConstructor()


### PR DESCRIPTION
# Before
```
Humbug running test suite to generate logs and code coverage data...
Humbug has completed the initial test run successfully.
Tests: 59 Line Coverage: 100.00%
Humbug is analysing source files...
Mutation Testing is commencing on 7 files...
(.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out)
.........MM.....MM......
24 mutations were generated:
      20 mutants were killed
       0 mutants were not covered by tests
       4 covered mutants were not detected
       0 fatal errors were encountered
       0 time outs were encountered

Metrics:
    Mutation Score Indicator (MSI): 83%
    Mutation Code Coverage: 100%
    Covered Code MSI: 83%

Remember that some mutants will inevitably be harmless (i.e. false positives).
Time: 9.29 seconds Memory: 6.00MB
Humbug results are being logged as TEXT to: humbuglog.txt

------
Escapes
------


1) \Humbug\Mutator\ConditionalNegation\Equal
Diff on \EnliteMonolog\Service\MonologServiceFactory::createHandler() in /Users/abacaphiliac/github.com/enlitepro/enlite-monolog/src/EnliteMonolog/Service/MonologServiceFactory.php:
--- Original
+++ New
@@ @@
             foreach ($options->getHandlers() as $key => $option) {
-                if ($arguments['handler'] == $key) {
+                if ($arguments['handler'] != $key) {
                     $arguments['handler'] = $this->createHandler($container, $options, $option);
                     break;
                 }
             }
         }
 


2) \Humbug\Mutator\Number\IntegerValue
Diff on \EnliteMonolog\Service\MonologServiceFactory::createHandler() in /Users/abacaphiliac/github.com/enlitepro/enlite-monolog/src/EnliteMonolog/Service/MonologServiceFactory.php:
--- Original
+++ New
@@ @@
                 $handlerClassName
-            ), 0, $exception);
+            ), 1, $exception);
         }
 
         if (isset($handler['formatter'])) {
             $formatter = $this->createFormatter($container, $handler['formatter']);
             $instance->setFormatter($formatter);
         }


3) \Humbug\Mutator\Number\IntegerValue
Diff on \EnliteMonolog\Service\MonologServiceFactory::createFormatter() in /Users/abacaphiliac/github.com/enlitepro/enlite-monolog/src/EnliteMonolog/Service/MonologServiceFactory.php:
--- Original
+++ New
@@ @@
                 $formatterClassName
-            ), 0, $exception);
+            ), 1, $exception);
         }
 
         return $instance;
     }
 
     /**


4) \Humbug\Mutator\Boolean\LogicalAnd
Diff on \EnliteMonolog\Service\MonologServiceFactory::createProcessor() in /Users/abacaphiliac/github.com/enlitepro/enlite-monolog/src/EnliteMonolog/Service/MonologServiceFactory.php:
--- Original
+++ New
@@ @@
 
-            if ($instance && is_callable($instance)) {
+            if ($instance || is_callable($instance)) {
                 return $instance;
             }
 
             $processor = new $processor();
 
             if (is_callable($processor)) {
```

# After
```
Humbug running test suite to generate logs and code coverage data...
Humbug has completed the initial test run successfully.
Tests: 60 Line Coverage: 100.00%
Humbug is analysing source files...
Mutation Testing is commencing on 7 files...
(.: killed, M: escaped, S: uncovered, E: fatal error, T: timed out)
.........M..............
24 mutations were generated:
      23 mutants were killed
       0 mutants were not covered by tests
       1 covered mutants were not detected
       0 fatal errors were encountered
       0 time outs were encountered

Metrics:
    Mutation Score Indicator (MSI): 96%
    Mutation Code Coverage: 100%
    Covered Code MSI: 96%

Remember that some mutants will inevitably be harmless (i.e. false positives).
Time: 9.03 seconds Memory: 6.00MB
Humbug results are being logged as TEXT to: humbuglog.txt

------
Escapes
------


1) \Humbug\Mutator\ConditionalNegation\Equal
Diff on \EnliteMonolog\Service\MonologServiceFactory::createHandler() in /Users/abacaphiliac/github.com/enlitepro/enlite-monolog/src/EnliteMonolog/Service/MonologServiceFactory.php:
--- Original
+++ New
@@ @@
             foreach ($options->getHandlers() as $key => $option) {
-                if ($arguments['handler'] == $key) {
+                if ($arguments['handler'] != $key) {
                     $arguments['handler'] = $this->createHandler($container, $options, $option);
                     break;
                 }
             }
         }
```