### PR TITLE
add container-interop as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "zendframework/zend-servicemanager": "^2 || ^3"
     },
     "require-dev": {
+        "container-interop/container-interop": "^1.0",
         "jakub-onderka/php-parallel-lint": "^0.9",
         "johnkary/phpunit-speedtrap": "^1.0",
         "squizlabs/php_codesniffer": "^2.9",

--- a/test/EnliteMonologTest/Service/ContainerMock.php
+++ b/test/EnliteMonologTest/Service/ContainerMock.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Zend\ServiceManager\ServiceManager;
+
+class ContainerMock implements ContainerInterface
+{
+    /** @var ServiceManager */
+    private $services;
+
+    /**
+     * ContainerMock constructor.
+     * @param ServiceManager $services
+     */
+    public function __construct(ServiceManager $services)
+    {
+        $this->services = $services;
+    }
+
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id)
+    {
+        return $this->services->get($id);
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has($id)
+    {
+        return $this->services->has($id);
+    }
+}

--- a/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceAbstractFactoryTest.php
@@ -90,10 +90,6 @@ class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $services = new ServiceManager();
 
-        if (!$services instanceof ContainerInterface) {
-            self::markTestSkipped('container-interop/container-interop is required.');
-        }
-
         $sut = new MonologServiceAbstractFactory();
 
         $services->setService(
@@ -105,17 +101,13 @@ class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        self::assertTrue($sut->canCreate($services, 'default'));
+        self::assertTrue($sut->canCreate(new ContainerMock($services), 'default'));
     }
 
     public function testInvoke()
     {
         $services = new ServiceManager();
 
-        if (!$services instanceof ContainerInterface) {
-            self::markTestSkipped('container-interop/container-interop is required.');
-        }
-
         $sut = new MonologServiceAbstractFactory();
 
         $services->setService(
@@ -127,7 +119,7 @@ class MonologServiceAbstractFactoryTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $logger = $sut($services, 'default');
+        $logger = $sut(new ContainerMock($services), 'default');
 
         self::assertInstanceOf('\Monolog\Logger', $logger);
     }

--- a/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceFactoryTest.php
@@ -394,17 +394,13 @@ class MonologServiceFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $services = new ServiceManager();
 
-        if (!$services instanceof ContainerInterface) {
-            self::markTestSkipped('container-interop/container-interop is required.');
-        }
-
         $config = array('name' => 'test', 'handlers' => array(array('name' => 'Monolog\Handler\TestHandler')));
 
         $services->setService('EnliteMonologOptions', new MonologOptions($config));
 
         $sut = new MonologServiceFactory();
 
-        $service = $sut($services, 'EnliteMonolog');
+        $service = $sut(new ContainerMock($services), 'EnliteMonolog');
         $this->assertInstanceOf('Monolog\Logger', $service);
         $this->assertEquals('test', $service->getName());
 

--- a/test/EnliteMonologTest/Service/MonologServiceInitializerTest.php
+++ b/test/EnliteMonologTest/Service/MonologServiceInitializerTest.php
@@ -89,15 +89,11 @@ class MonologServiceInitializerTest extends \PHPUnit_Framework_TestCase
 
         $services = new ServiceManager();
 
-        if (!$services instanceof ContainerInterface) {
-            self::markTestSkipped('container-interop/container-interop is required.');
-        }
-
         $services->setService('EnliteMonologService', $logger);
 
         $sut = new MonologServiceInitializer();
 
-        self::assertNull($sut($services, $service));
+        self::assertNull($sut(new ContainerMock($services), $service));
 
         self::assertSame($logger, $service->getMonologService());
     }
@@ -108,12 +104,8 @@ class MonologServiceInitializerTest extends \PHPUnit_Framework_TestCase
 
         $services = new ServiceManager();
 
-        if (!$services instanceof ContainerInterface) {
-            self::markTestSkipped('container-interop/container-interop is required.');
-        }
-
         $sut = new MonologServiceInitializer();
 
-        self::assertNull($sut($services, $service));
+        self::assertNull($sut(new ContainerMock($services), $service));
     }
 }


### PR DESCRIPTION
fixes #37 

add container-interop as a dev dependency so that these interfaces are available to test, even when older versions of zend-servicemanager are installed. add ContainerMock to wrap ServiceManager so that all >=php54 tests are executed; only the trait tests are skipped in php53 builds.