### PR TITLE
exclude tests (etc) from install via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/test export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+humbug.json.dist export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
add .gitattributes file with export-ignore to exclude tests (etc) from package zip downloaded by composer, a la https://blog.madewithlove.be/post/gitattributes/