### PR TITLE
register logger(s) as error handler(s) (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ $serviceLocator->get('EnliteMonologService')->addDebug('hello world');
 $serviceLocator->get('MyChromeLogger')->addInfo('hello world');
 ```
 
+## Error Handlers
+
+Update your application config:
+```php
+return [
+    'EnliteMonologErrorHandlers' => [
+        'EnliteMonologService' => [
+            'logger' => 'EnliteMonologService',
+        ],
+    ],
+];
+```
+
+Error-handler loggers must be implementations of PSR logger interface, provided by your application's container.
+
+Error, exception, and fatal error handling is enabled by default for each of these loggers,
+but you can disable or tweak these behaviors through configuration.
+
 ## Contributing
 
 This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "jakub-onderka/php-parallel-lint": "^0.9",
         "johnkary/phpunit-speedtrap": "^1.0",
         "squizlabs/php_codesniffer": "^2.9",
-        "phpunit/phpunit": "^5|^4.8"
+        "phpunit/phpunit": "^6|^5|^4.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/EnliteMonolog/Module.php
+++ b/src/EnliteMonolog/Module.php
@@ -5,13 +5,26 @@
 
 namespace EnliteMonolog;
 
+use EnliteMonolog\Service\ErrorHandlerListener;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Zend\ModuleManager\Feature\InitProviderInterface;
+use Zend\ModuleManager\ModuleManagerInterface;
 
 class Module implements
     AutoloaderProviderInterface,
+    InitProviderInterface,
     ConfigProviderInterface
 {
+    /**
+     * @param ModuleManagerInterface $moduleManager
+     * @return void
+     */
+    public function init(ModuleManagerInterface $moduleManager)
+    {
+        $errorHandlerListener = new ErrorHandlerListener();
+        $errorHandlerListener->attach($moduleManager->getEventManager());
+    }
 
     /**
      * {@inheritdoc}

--- a/src/EnliteMonolog/Service/ErrorHandlerListener.php
+++ b/src/EnliteMonolog/Service/ErrorHandlerListener.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace EnliteMonolog\Service;
+
+use Monolog\ErrorHandler;
+use Psr\Log\LoggerInterface;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * TODO Require zendframework/zend-eventmanager:^2.2, extend AbstractListenerAggregate, and drop custom detach.
+ */
+class ErrorHandlerListener implements ListenerAggregateInterface
+{
+    /**
+     * @var callable[]
+     */
+    private $listeners = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function detach(EventManagerInterface $events)
+    {
+        foreach ($this->listeners as $index => $callback) {
+            $events->detach($callback);
+            unset($this->listeners[$index]);
+        }
+    }
+
+    /**
+     * Attach one or more listeners
+     *
+     * Implementors may add an optional $priority argument; the EventManager
+     * implementation will pass this to the aggregate.
+     *
+     * @param EventManagerInterface $events
+     * @param int $priority
+     * @return void
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(ModuleEvent::EVENT_LOAD_MODULES_POST, array(
+            $this,
+            'registerErrorHandlers'
+        ));
+    }
+
+    /**
+     * @param EventInterface $event
+     * @return ErrorHandler[]
+     */
+    public function registerErrorHandlers(EventInterface $event)
+    {
+        $services = $event->getParam('ServiceManager');
+        if (!$services instanceof ServiceLocatorInterface) {
+            return array();
+        }
+
+        $config = array();
+        if ($services->has('config')) {
+            $config = $services->get('config');
+        } elseif ($event instanceof ModuleEvent) {
+            $config = $event->getConfigListener()->getMergedConfig(false);
+        }
+
+        if (!is_array($config)) {
+            return array();
+        }
+
+        if (!array_key_exists('EnliteMonologErrorHandlers', $config)) {
+            return array();
+        }
+
+        $handlers = $config['EnliteMonologErrorHandlers'];
+        if (!is_array($handlers) || count($handlers) < 1) {
+            return array();
+        }
+
+        // Transform error-handler configurations into option objects.
+        $handlers = array_map(function ($config) {
+            return new ErrorHandlerOptions($config);
+        }, $handlers);
+
+        // Transform error-handler options into error-handler instances.
+        return array_map(function (ErrorHandlerOptions $options) use ($services) {
+            if (!$services->has($options->getLogger())) {
+                return null;
+            }
+
+            $logger = $services->get($options->getLogger());
+
+            if (!$logger instanceof LoggerInterface) {
+                return null;
+            }
+
+            if (class_exists('\Monolog\ErrorHandler')) {
+                return ErrorHandler::register(
+                    $logger,
+                    $options->getErrorLevelMap(),
+                    $options->getExceptionLevel(),
+                    $options->getFatalLevel()
+                );
+            }
+
+            return null;
+        }, $handlers);
+    }
+}

--- a/src/EnliteMonolog/Service/ErrorHandlerOptions.php
+++ b/src/EnliteMonolog/Service/ErrorHandlerOptions.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EnliteMonolog\Service;
+
+use Zend\Stdlib\AbstractOptions;
+
+class ErrorHandlerOptions extends AbstractOptions
+{
+    /** @var string|null */
+    private $logger = null;
+
+    /** @var array|boolean */
+    private $errorLevelMap = array();
+
+    /** @var mixed|null */
+    private $exceptionLevel = null;
+
+    /** @var mixed|null */
+    private $fatalLevel = null;
+
+    /**
+     * @return null|string
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
+     * @param null|string $logger
+     * @return void
+     */
+    public function setLogger($logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return array|boolean
+     */
+    public function getErrorLevelMap()
+    {
+        return $this->errorLevelMap;
+    }
+
+    /**
+     * @param array|boolean $errorLevelMap
+     * @return void
+     */
+    public function setErrorLevelMap($errorLevelMap)
+    {
+        $this->errorLevelMap = $errorLevelMap;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getExceptionLevel()
+    {
+        return $this->exceptionLevel;
+    }
+
+    /**
+     * @param mixed|null $exceptionLevel
+     * @return void
+     */
+    public function setExceptionLevel($exceptionLevel)
+    {
+        $this->exceptionLevel = $exceptionLevel;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getFatalLevel()
+    {
+        return $this->fatalLevel;
+    }
+
+    /**
+     * @param mixed|null $fatalLevel
+     * @return void
+     */
+    public function setFatalLevel($fatalLevel)
+    {
+        $this->fatalLevel = $fatalLevel;
+    }
+}

--- a/test/EnliteMonologTest/ModuleTest.php
+++ b/test/EnliteMonologTest/ModuleTest.php
@@ -3,6 +3,11 @@
 namespace EnliteMonologTest\Module;
 
 use EnliteMonolog\Module;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\ModuleManager;
+use Zend\ServiceManager\ServiceManager;
 
 /**
  * @covers \EnliteMonolog\Module
@@ -41,5 +46,58 @@ class ModuleTest extends \PHPUnit_Framework_TestCase
     public function testConfigIsSerializable()
     {
         self::assertInternalType('array', unserialize(serialize($this->sut->getConfig())));
+    }
+
+    /**
+     * @runInSeparateProcess \Monolog\ErrorHandler::register has side-effects.
+     */
+    public function testInitMultipleErrorHandlers()
+    {
+        if (!class_exists('\Monolog\ErrorHandler')) {
+            self::markTestSkipped('monolog\monolog:^1.6 is required.');
+        }
+
+        $logger = new Logger(__METHOD__, array(
+            $handler = new TestHandler(),
+        ));
+
+        $anotherLogger = new Logger(__METHOD__, array(
+            $anotherHandler = new TestHandler(),
+        ));
+
+        $services = new ServiceManager();
+        $services->setService('FooBar', $logger);
+        $services->setService('FizBuz', $anotherLogger);
+        $services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+                'FizBuz' => array(
+                    'logger' => 'FizBuz',
+                ),
+            ),
+        ));
+
+        $event = new ModuleEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $this, array(
+            'ServiceManager' => $services,
+        ));
+
+        $modules = new ModuleManager(array());
+
+        $this->sut->init($modules);
+
+        ErrorHandlerListenerTest::triggerModuleEvent($modules, $event);
+
+        self::assertCount(0, $handler->getRecords());
+        self::assertCount(0, $anotherHandler->getRecords());
+
+        try {
+            \trigger_error('whoops');
+        } catch (\Exception $e) {
+        }
+
+        self::assertCount(1, $handler->getRecords());
+        self::assertCount(1, $anotherHandler->getRecords());
     }
 }

--- a/test/EnliteMonologTest/Service/ErrorHandlerListenerTest.php
+++ b/test/EnliteMonologTest/Service/ErrorHandlerListenerTest.php
@@ -1,0 +1,383 @@
+<?php
+
+namespace EnliteMonologTest\Module;
+
+use EnliteMonolog\Service\ErrorHandlerListener;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Zend\EventManager\EventManagerInterface;
+use Zend\ModuleManager\Listener\ConfigListener;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\ModuleManager;
+use Zend\ServiceManager\ServiceManager;
+
+/**
+ * @covers \EnliteMonolog\Service\ErrorHandlerListener
+ * @runTestsInSeparateProcesses \Monolog\ErrorHandler::register has side-effects.
+ */
+class ErrorHandlerListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var TestHandler */
+    private $handler;
+
+    /** @var EventManagerInterface */
+    private $events;
+
+    /** @var ModuleManager */
+    private $modules;
+
+    /** @var ConfigListener */
+    private $configListener;
+
+    /** @var ModuleEvent */
+    private $event;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject|Logger */
+    private $mockLogger;
+
+    /** @var Logger */
+    private $logger;
+
+    /** @var ServiceManager */
+    private $services;
+
+    /** @var ErrorHandlerListener */
+    private $sut;
+
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists('\Monolog\ErrorHandler')) {
+            self::markTestSkipped('monolog\monolog:^1.6 is required.');
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->services = new ServiceManager();
+
+        $this->handler = new TestHandler();
+
+        $this->logger = new Logger(__METHOD__, array(
+            $this->handler,
+        ));
+
+        $this->mockLogger = $this->getMockBuilder('\Psr\Log\LoggerInterface')
+            ->getMock();
+
+        $this->configListener = new ConfigListener();
+
+        $this->event = new ModuleEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $this, array(
+            'ServiceManager' => $this->services,
+        ));
+
+        $this->event->setConfigListener($this->configListener);
+
+        $this->modules = new ModuleManager(array());
+
+        $this->events = $this->modules->getEventManager();
+
+        $this->sut = new ErrorHandlerListener();
+
+        $this->sut->attach($this->events);
+    }
+
+    public function testRegisterErrorHandlers()
+    {
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+                'FizBuz' => array(
+                    'logger' => 'FizBuz',
+                ),
+            ),
+        ));
+
+        $this->services->setService('FooBar', $this->logger);
+
+        $this->services->setService('FizBuz', $this->mockLogger);
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertArrayHasKey('FooBar', $handlers);
+        self::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FooBar']);
+
+        self::assertArrayHasKey('FizBuz', $handlers);
+        self::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FizBuz']);
+    }
+
+    public function testRegisterErrorHandlersViaConfigListener()
+    {
+        $this->configListener->setMergedConfig(array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+                'FizBuz' => array(
+                    'logger' => 'FizBuz',
+                ),
+            ),
+        ));
+
+        $this->services->setService('FooBar', $this->logger);
+
+        $this->services->setService('FizBuz', $this->mockLogger);
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertArrayHasKey('FooBar', $handlers);
+        self::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FooBar']);
+
+        self::assertArrayHasKey('FizBuz', $handlers);
+        self::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FizBuz']);
+    }
+
+    public function testNotRegisterErrorHandlersDueToMissingContainer()
+    {
+        $event = new ModuleEvent();
+
+        $handlers = $this->sut->registerErrorHandlers($event);
+
+        self::assertCount(0, $handlers);
+    }
+
+    public function testNotRegisterErrorHandlersDueToInvalidConfig()
+    {
+        $this->services->setService('config', new \stdClass());
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertCount(0, $handlers);
+    }
+
+    public function testNotRegisterErrorHandlersDueToMissingConfigList()
+    {
+        $this->services->setService('config', array(
+
+        ));
+
+        $event = new ModuleEvent(ModuleEvent::EVENT_LOAD_MODULES_POST, $this, array(
+            'ServiceManager' => $this->services,
+        ));
+
+        $handlers = $this->sut->registerErrorHandlers($event);
+
+        self::assertCount(0, $handlers);
+    }
+
+    public function testNotRegisterErrorHandlersDueToInvalidConfigList()
+    {
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => 'FooBar',
+        ));
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertCount(0, $handlers);
+    }
+
+    public function testNotRegisterErrorHandlersDueToEmptyConfigList()
+    {
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+
+            ),
+        ));
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertCount(0, $handlers);
+    }
+
+    public function testNotRegisterErrorHandlersDueToMissingLogger()
+    {
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+            ),
+        ));
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertArrayHasKey('FooBar', $handlers);
+        self::assertNull($handlers['FooBar']);
+    }
+
+    public function testNotRegisterErrorHandlersDueToInvalidLogger()
+    {
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+            ),
+        ));
+
+        $this->services->setService('FooBar', new \stdClass());
+
+        $handlers = $this->sut->registerErrorHandlers($this->event);
+
+        self::assertArrayHasKey('FooBar', $handlers);
+        self::assertNull($handlers['FooBar']);
+    }
+
+    /**
+     * Normalizes event-manager trigger functionality, between versions 2 and 3.
+     *
+     * @param ModuleManager $modules
+     * @param ModuleEvent $event
+     * @return \Zend\EventManager\ResponseCollection
+     */
+    public static function triggerModuleEvent(ModuleManager $modules, ModuleEvent $event)
+    {
+        $events = $modules->getEventManager();
+
+        if (is_callable(array($events, 'setEventPrototype'))) {
+            $events->setEventPrototype($event);
+        }
+
+        if (is_callable(array($events, 'triggerEvent'))) {
+            return $events->triggerEvent($event);
+        }
+
+        if (is_callable(array($events, 'setEventPrototype'))) {
+            return $events->trigger($event->getName(), $event->getTarget(), $event->getParams());
+        } else {
+            return $events->trigger($event);
+        }
+    }
+
+    public function testInitRegistersErrorHandlers()
+    {
+        $this->services->setService('FooBar', $this->logger);
+        $this->services->setService('FizBuz', $this->mockLogger);
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+                'FizBuz' => array(
+                    'logger' => 'FizBuz',
+                ),
+            ),
+        ));
+
+        $responses = self::triggerModuleEvent($this->modules, $this->event);
+
+        self::assertCount(1, $responses);
+        self::assertInternalType('array', $handlers = $responses[0]);
+
+        \PHPUnit_Framework_TestCase::assertArrayHasKey('FooBar', $handlers);
+        \PHPUnit_Framework_TestCase::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FooBar']);
+
+        \PHPUnit_Framework_TestCase::assertArrayHasKey('FizBuz', $handlers);
+        \PHPUnit_Framework_TestCase::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FizBuz']);
+    }
+
+    public function testRegisterErrorHandlerOnly()
+    {
+        $this->services->setService('FooBar', $this->logger);
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                    'exceptionLevel' => false,
+                    'fatalLevel' => false,
+                ),
+            ),
+        ));
+
+        self::triggerModuleEvent($this->modules, $this->event);
+
+        self::assertCount(0, $this->handler->getRecords());
+
+        try {
+            \trigger_error('whoops');
+        } catch (\Exception $e) {
+        }
+
+        self::assertCount(1, $this->handler->getRecords());
+    }
+
+    public function testRegisterMultipleErrorHandlers()
+    {
+        $anotherHandler = new TestHandler();
+
+        $anotherLogger = new Logger(__METHOD__, array(
+            $anotherHandler
+        ));
+
+        $this->services->setService('FooBar', $this->logger);
+        $this->services->setService('FizBuz', $anotherLogger);
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                ),
+                'FizBuz' => array(
+                    'logger' => 'FizBuz',
+                ),
+            ),
+        ));
+
+        self::triggerModuleEvent($this->modules, $this->event);
+
+        self::assertCount(0, $this->handler->getRecords());
+        self::assertCount(0, $anotherHandler->getRecords());
+
+        try {
+            \trigger_error('whoops');
+        } catch (\Exception $e) {
+        }
+
+        self::assertCount(1, $this->handler->getRecords());
+        self::assertCount(1, $anotherHandler->getRecords());
+    }
+
+    public function testRegisterExceptionHandlerOnly()
+    {
+        $this->services->setService('FooBar', $this->logger);
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                    'errorLevelMap' => false,
+                    'fatalLevel' => false,
+                ),
+            ),
+        ));
+
+        $responses = self::triggerModuleEvent($this->modules, $this->event);
+
+        self::assertCount(1, $responses);
+        self::assertInternalType('array', $handlers = $responses[0]);
+
+        \PHPUnit_Framework_TestCase::assertArrayHasKey('FooBar', $handlers);
+        \PHPUnit_Framework_TestCase::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FooBar']);
+    }
+
+    public function testRegisterFatalHandlerOnly()
+    {
+        $this->services->setService('FooBar', $this->logger);
+        $this->services->setService('config', array(
+            'EnliteMonologErrorHandlers' => array(
+                'FooBar' => array(
+                    'logger' => 'FooBar',
+                    'errorLevelMap' => false,
+                    'exceptionLevel' => false,
+                ),
+            ),
+        ));
+
+        $responses = self::triggerModuleEvent($this->modules, $this->event);
+
+        self::assertCount(1, $responses);
+        self::assertInternalType('array', $handlers = $responses[0]);
+
+        \PHPUnit_Framework_TestCase::assertArrayHasKey('FooBar', $handlers);
+        \PHPUnit_Framework_TestCase::assertInstanceOf('\Monolog\ErrorHandler', $handlers['FooBar']);
+    }
+}

--- a/test/EnliteMonologTest/Service/ErrorHandlerOptionsTest.php
+++ b/test/EnliteMonologTest/Service/ErrorHandlerOptionsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace EnliteMonologTest\Service;
+
+use EnliteMonolog\Service\ErrorHandlerOptions;
+
+/**
+ * @covers \EnliteMonolog\Service\ErrorHandlerOptions
+ */
+class ErrorHandlerOptionsTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ErrorHandlerOptions */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new ErrorHandlerOptions();
+    }
+
+    public function testGetLogger()
+    {
+        self::assertNull($this->sut->getLogger());
+
+        $this->sut->setLogger('FooBar');
+
+        self::assertSame('FooBar', $this->sut->getLogger());
+    }
+
+    public function testDisableLogger()
+    {
+        $this->sut->setLogger(false);
+
+        self::assertFalse($this->sut->getLogger());
+    }
+
+    public function testGetErrorLevelMap()
+    {
+        self::assertCount(0, $this->sut->getErrorLevelMap());
+
+        $this->sut->setErrorLevelMap(array(
+            \E_ERROR => 'critical',
+        ));
+
+        self::assertSame(array(\E_ERROR => 'critical'), $this->sut->getErrorLevelMap());
+    }
+
+    public function testDisableErrorHandler()
+    {
+        $this->sut->setErrorLevelMap(false);
+
+        self::assertFalse($this->sut->getErrorLevelMap());
+    }
+
+    public function testGetExceptionLevel()
+    {
+        self::assertNull($this->sut->getExceptionLevel());
+
+        $this->sut->setExceptionLevel('critical');
+
+        self::assertSame('critical', $this->sut->getExceptionLevel());
+    }
+
+    public function testDisableExceptionHandler()
+    {
+        $this->sut->setExceptionLevel(false);
+
+        self::assertFalse($this->sut->getExceptionLevel());
+    }
+
+    public function testGetFatalLevel()
+    {
+        self::assertNull($this->sut->getFatalLevel());
+
+        $this->sut->setFatalLevel('critical');
+
+        self::assertSame('critical', $this->sut->getFatalLevel());
+    }
+
+    public function testDisableFatalHandler()
+    {
+        $this->sut->setFatalLevel(false);
+
+        self::assertFalse($this->sut->getFatalLevel());
+    }
+}

--- a/test/ZF2/IntegrationTest/IntegrationTest.php
+++ b/test/ZF2/IntegrationTest/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace EnliteMonologTest\ZF2\IntegrationTest;
 
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
@@ -33,5 +34,47 @@ class IntegrationTest extends TestCase
         $logger = $services->get('EnliteMonologService');
 
         self::assertInstanceOf('\Monolog\Logger', $logger);
+    }
+
+    /**
+     * @runInSeparateProcess \Monolog\ErrorHandler::register has side-effects.
+     */
+    public function testRegistersErrorHandler()
+    {
+        if (!class_exists('\Monolog\ErrorHandler')) {
+            self::markTestSkipped('monolog\monolog:^1.6 is required.');
+        }
+
+        $application = Application::init(array(
+            'module_listener_options' => array(
+                'config_glob_paths' => array(
+                    __DIR__ . '/config/{{,*.}global,{,*.}local}.php',
+                ),
+            ),
+            'modules' => array(
+                'EnliteMonolog',
+            ),
+        ));
+
+        $services = $application->getServiceManager();
+
+        /** @var Logger $logger */
+        $logger = $services->get('ErrorLogger');
+
+        self::assertInstanceOf('\Monolog\Logger', $logger);
+        self::assertCount(1, $handlers = $logger->getHandlers());
+
+        /** @var TestHandler $handler */
+        $handler = $handlers[0];
+        self::assertInstanceOf('\Monolog\Handler\TestHandler', $handler);
+
+        self::assertCount(0, $handler->getRecords());
+
+        try {
+            \trigger_error('whoops');
+        } catch (\Exception $e) {
+        }
+
+        self::assertCount(1, $handler->getRecords());
     }
 }

--- a/test/ZF2/IntegrationTest/config/errors.global.php
+++ b/test/ZF2/IntegrationTest/config/errors.global.php
@@ -1,0 +1,19 @@
+<?php
+
+return array(
+    'EnliteMonologErrorHandlers' => array(
+        'EnliteMonologService' => array(
+            'logger' => 'ErrorLogger',
+        ),
+    ),
+    'EnliteMonolog' => array(
+        'ErrorLogger' => array(
+            'name' => 'ErrorLogger',
+            'handlers' => array(
+                'TestHandler' => array(
+                    'name' => 'Monolog\Handler\TestHandler',
+                ),
+            ),
+        ),
+    ),
+);

--- a/test/ZF3/IntegrationTest/IntegrationTest.php
+++ b/test/ZF3/IntegrationTest/IntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace EnliteMonologTest\ZF2\IntegrationTest;
 
+use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Application;
@@ -34,5 +35,48 @@ class IntegrationTest extends TestCase
         $logger = $services->get('EnliteMonologService');
 
         self::assertInstanceOf('\Monolog\Logger', $logger);
+    }
+
+    /**
+     * @runInSeparateProcess \Monolog\ErrorHandler::register has side-effects.
+     */
+    public function testRegistersErrorHandler()
+    {
+        if (!class_exists('\Monolog\ErrorHandler')) {
+            self::markTestSkipped('monolog\monolog:^1.6 is required.');
+        }
+
+        $application = Application::init(array(
+            'module_listener_options' => array(
+                'config_glob_paths' => array(
+                    __DIR__ . '/config/{{,*.}global,{,*.}local}.php',
+                ),
+            ),
+            'modules' => array(
+                'Zend\Router',
+                'EnliteMonolog',
+            ),
+        ));
+
+        $services = $application->getServiceManager();
+
+        /** @var Logger $logger */
+        $logger = $services->get('ErrorLogger');
+
+        self::assertInstanceOf('\Monolog\Logger', $logger);
+        self::assertCount(1, $handlers = $logger->getHandlers());
+
+        /** @var TestHandler $handler */
+        $handler = $handlers[0];
+        self::assertInstanceOf('\Monolog\Handler\TestHandler', $handler);
+
+        self::assertCount(0, $handler->getRecords());
+
+        try {
+            \trigger_error('whoops');
+        } catch (\Exception $e) {
+        }
+
+        self::assertCount(1, $handler->getRecords());
     }
 }

--- a/test/ZF3/IntegrationTest/config/errors.global.php
+++ b/test/ZF3/IntegrationTest/config/errors.global.php
@@ -1,0 +1,19 @@
+<?php
+
+return array(
+    'EnliteMonologErrorHandlers' => array(
+        'EnliteMonologService' => array(
+            'logger' => 'ErrorLogger',
+        ),
+    ),
+    'EnliteMonolog' => array(
+        'ErrorLogger' => array(
+            'name' => 'ErrorLogger',
+            'handlers' => array(
+                'TestHandler' => array(
+                    'name' => 'Monolog\Handler\TestHandler',
+                ),
+            ),
+        ),
+    ),
+);


### PR DESCRIPTION
adds module init listener to register loggers as error handlers. this is a configurable (opt-in) behavior.